### PR TITLE
Bump version to v0.0.1

### DIFF
--- a/src/libgaus/request.c
+++ b/src/libgaus/request.c
@@ -19,7 +19,7 @@
 #include "gaus.h"
 
 #ifndef VERSION
-#define VERSION "v0.0.0"
+#define VERSION "v0.0.1"
 #endif
 
 


### PR DESCRIPTION
Changes since v0.0.0:
  - Raw log only support via define
  - Disable ca cert check via define
  - Version defined if not defined